### PR TITLE
Get original maker order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Docs about publishing NPM package
 
+### Added
+
+- Introduced a new rpc call (GetOriginalMakerOrder) that returns the original Maker Transaction with respect to the transaction hash and index provided as arguments.  
+
+
 ## [0.3.1] - 2021-12-03
 
 ### Added

--- a/impl/javascript/proto/bc_grpc_pb.js
+++ b/impl/javascript/proto/bc_grpc_pb.js
@@ -1085,6 +1085,17 @@ var BcService = exports.BcService = {
     responseSerialize: serialize_bc_exchange_GetOpenOrdersResponse,
     responseDeserialize: deserialize_bc_exchange_GetOpenOrdersResponse,
   },
+  getOriginalMakerOrder: {
+    path: '/bc.exchange.Bc/GetOriginalMakerOrder',
+    requestStream: false,
+    responseStream: false,
+    requestType: bc_pb.GetOutPointRequest,
+    responseType: core_pb.Transaction,
+    requestSerialize: serialize_bc_exchange_GetOutPointRequest,
+    requestDeserialize: deserialize_bc_exchange_GetOutPointRequest,
+    responseSerialize: serialize_bc_core_Transaction,
+    responseDeserialize: deserialize_bc_core_Transaction,
+  },
   getUtxos: {
     path: '/bc.exchange.Bc/GetUtxos',
     requestStream: false,

--- a/impl/javascript/proto/bc_pb_service.d.ts
+++ b/impl/javascript/proto/bc_pb_service.d.ts
@@ -392,6 +392,15 @@ type BcGetUnmatchedOrders = {
   readonly responseType: typeof bc_pb.GetOpenOrdersResponse;
 };
 
+type BcGetOriginalMakerOrder = {
+  readonly methodName: string;
+  readonly service: typeof Bc;
+  readonly requestStream: false;
+  readonly responseStream: false;
+  readonly requestType: typeof bc_pb.GetOutPointRequest;
+  readonly responseType: typeof core_pb.Transaction;
+};
+
 type BcGetUtxos = {
   readonly methodName: string;
   readonly service: typeof Bc;
@@ -518,6 +527,7 @@ export class Bc {
   static readonly GetMatchedOrders: BcGetMatchedOrders;
   static readonly GetHistoricalOrders: BcGetHistoricalOrders;
   static readonly GetUnmatchedOrders: BcGetUnmatchedOrders;
+  static readonly GetOriginalMakerOrder: BcGetOriginalMakerOrder;
   static readonly GetUtxos: BcGetUtxos;
   static readonly GetUTXOLength: BcGetUTXOLength;
   static readonly GetSTXOLength: BcGetSTXOLength;
@@ -947,6 +957,15 @@ export class BcClient {
   getUnmatchedOrders(
     requestMessage: bc_pb.GetBalanceRequest,
     callback: (error: ServiceError|null, responseMessage: bc_pb.GetOpenOrdersResponse|null) => void
+  ): UnaryResponse;
+  getOriginalMakerOrder(
+    requestMessage: bc_pb.GetOutPointRequest,
+    metadata: grpc.Metadata,
+    callback: (error: ServiceError|null, responseMessage: core_pb.Transaction|null) => void
+  ): UnaryResponse;
+  getOriginalMakerOrder(
+    requestMessage: bc_pb.GetOutPointRequest,
+    callback: (error: ServiceError|null, responseMessage: core_pb.Transaction|null) => void
   ): UnaryResponse;
   getUtxos(
     requestMessage: bc_pb.GetUtxosRequest,

--- a/impl/javascript/proto/bc_pb_service.js
+++ b/impl/javascript/proto/bc_pb_service.js
@@ -398,6 +398,15 @@ Bc.GetUnmatchedOrders = {
   responseType: bc_pb.GetOpenOrdersResponse
 };
 
+Bc.GetOriginalMakerOrder = {
+  methodName: "GetOriginalMakerOrder",
+  service: Bc,
+  requestStream: false,
+  responseStream: false,
+  requestType: bc_pb.GetOutPointRequest,
+  responseType: core_pb.Transaction
+};
+
 Bc.GetUtxos = {
   methodName: "GetUtxos",
   service: Bc,
@@ -1793,6 +1802,37 @@ BcClient.prototype.getUnmatchedOrders = function getUnmatchedOrders(requestMessa
     callback = arguments[1];
   }
   var client = grpc.unary(Bc.GetUnmatchedOrders, {
+    request: requestMessage,
+    host: this.serviceHost,
+    metadata: metadata,
+    transport: this.options.transport,
+    debug: this.options.debug,
+    onEnd: function (response) {
+      if (callback) {
+        if (response.status !== grpc.Code.OK) {
+          var err = new Error(response.statusMessage);
+          err.code = response.status;
+          err.metadata = response.trailers;
+          callback(err, null);
+        } else {
+          callback(null, response.message);
+        }
+      }
+    }
+  });
+  return {
+    cancel: function () {
+      callback = null;
+      client.close();
+    }
+  };
+};
+
+BcClient.prototype.getOriginalMakerOrder = function getOriginalMakerOrder(requestMessage, metadata, callback) {
+  if (arguments.length === 2) {
+    callback = arguments[1];
+  }
+  var client = grpc.unary(Bc.GetOriginalMakerOrder, {
     request: requestMessage,
     host: this.serviceHost,
     metadata: metadata,

--- a/protos/bc.proto
+++ b/protos/bc.proto
@@ -382,6 +382,7 @@ service Bc {
 
     rpc GetUnmatchedOrders (GetBalanceRequest) returns (GetOpenOrdersResponse) {}
 
+    rpc GetOriginalMakerOrder (GetOutPointRequest) returns (core.Transaction) {}
     rpc GetUtxos (GetUtxosRequest) returns (core.Utxos) {}
     rpc GetUTXOLength (GetUtxoLengthRequest) returns (GetUtxoLengthResponse) {}
     rpc GetSTXOLength (GetUtxoLengthRequest) returns (GetUtxoLengthResponse) {}


### PR DESCRIPTION
introduces a new rpc for gettting the original maker order for a tx hash and index